### PR TITLE
Alpine texlive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,24 @@ PANDOC_COMMIT          ?= $(PANDOC_VERSION)
 PANDOC_CITEPROC_COMMIT ?= 0.15.0.1
 endif
 
-alpine:
-	docker build \
-	    --tag pandoc/core:$(PANDOC_VERSION) \
-	    --build-arg pandoc_commit=$(PANDOC_COMMIT) \
-	    --build-arg pandoc_citeproc_commit=$(PANDOC_CITEPROC_COMMIT) \
-	    alpine
-
+# Keep this target first so that `make` with no arguments will print this rather
+# than potentially engaging in expensive builds.
+.PHONY: show-args
 show-args:
 	@printf "PANDOC_VERSION (i.e. image version tag): %s\n" $(PANDOC_VERSION)
 	@printf "pandoc_commit=%s\n" $(PANDOC_COMMIT)
 	@printf "pandoc_citeproc_commit=%s\n" $(PANDOC_CITEPROC_COMMIT)
 
-.PHONY: alpine show-args
+.PHONY: alpine-base alpine-tex
+alpine-base:
+	docker build \
+	    --tag pandoc/core:$(PANDOC_VERSION) \
+	    --build-arg pandoc_commit=$(PANDOC_COMMIT) \
+	    --build-arg pandoc_citeproc_commit=$(PANDOC_CITEPROC_COMMIT) \
+	    alpine/
+alpine-tex:
+	docker build \
+	    --tag pandoc/alpine-tex:$(PANDOC_VERSION) \
+	    --build-arg base_tag=$(PANDOC_VERSION) \
+	    alpine/tex
+

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ show-args:
 	@printf "pandoc_commit=%s\n" $(PANDOC_COMMIT)
 	@printf "pandoc_citeproc_commit=%s\n" $(PANDOC_CITEPROC_COMMIT)
 
-.PHONY: alpine-base alpine-tex
-alpine-base:
+.PHONY: alpine alpine-tex
+alpine:
 	docker build \
 	    --tag pandoc/core:$(PANDOC_VERSION) \
 	    --build-arg pandoc_commit=$(PANDOC_COMMIT) \

--- a/alpine/tex/Dockerfile
+++ b/alpine/tex/Dockerfile
@@ -1,0 +1,26 @@
+ARG base_tag="master"
+FROM pandoc/core:${base_tag}
+
+# 1. Install `texlive-full` package, except for `texlive-doc`.  Run
+#    `apk -R info texlive-full` to see dependencies.  However, to help reduce
+#    the image size, instead of `texmf-dist-full` we choose `texmf-dist-most`.
+#    Users seeking Chinese, Cyrillic, Greek, Japanese, or Korean should install
+#    these packages (`texmf-dist-langchinese` for example), or install the
+#    wrapper package `texmf-dist-lang`.  This saves approximately 800MB, so we
+#    ask that users who need a specific language install it directly.
+#
+#    For an in-depth understanding of what options are available, see the
+#    package specification here:
+#
+#        https://git.alpinelinux.org/aports/tree/community/texmf-dist/APKBUILD
+#
+# 2. Install `libsrvg`, pandoc uses `rsvg-convert` for working with svg images.
+#
+# NOTE: to maintainers, please keep this listing alphabetical.
+RUN apk --no-cache add librsvg \
+                       texlive \
+                       texlive-dvi \
+                       texlive-luatex \
+                       texlive-xetex \
+                       texmf-dist-most \
+                       xdvik


### PR DESCRIPTION
Not quite ready for merge yet, see review.

Fixes #1 .

**Warning**: currently this produces a 2.25 GB image.  `ncdu` reveals that this is mostly fonts (specifically from `texmf-dist-most`), so maybe we can choose to be more selective with that.  But there seem to be a lot of hidden dependencies with latex and fonts that are actually required.

I can retry with less stuff installed, but I need guidance on how to actually test the full latex side of pandoc.