### PR TITLE
[WIP] Add Automated Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,80 @@
+# Need sudo to build and push the docker images.
+sudo: true
+dist: trusty
+
+# TODO: un-comment this when things seem to be working.
+# Builds are only run from the master branch.
+# branches:
+#   only:
+#   - master
+
+docker_build_script: &build_script
+  script:
+  # yaml gets upset using a colon for docker image tags, store in variable.
+  - colon="$(echo Ogo= | base64 --decode)"
+  - |
+    # TODO: TRAVIS_EVENT_TYPE, maybe check if == "cron" || == "api" for manual build?
+    #       need to test this and make sure api is the manual build button in website.
+    #       https://docs.travis-ci.com/user/environment-variables
+    # See: https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+    if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+      version="edge"
+    else
+      # See if this commit message asks for specifically `release=X.Y`
+      release_tag="$(echo "$TRAVIS_COMMIT_MESSAGE" | grep -o 'release=[0-9]\.[0-9]')"
+      if [ -z "$release_tag" ]; then
+        # Trigger new builds whenever things make it to master branch of
+        # pandoc/dockerfiles.
+        #
+        # TODO: or maybe only re-build things if a Dockerfile has changed?
+        #       git diff --name-only HEAD~1 | grep -c Dockerfile
+        version="edge"
+      else
+        # `release_tag` is of form `release=X.Y`, we just want X.Y
+        version="$(echo "$release_tag" | cut -d = -f 2)"
+      fi
+    fi
+
+    # Setup `repository` variable for where to pull / push a given image.  See
+    # rules defined in README.
+    if [ "$MAKE_TARGET" == "alpine" ]; then
+      repository="core"
+    elif [ "$MAKE_TARGET" == "alpine-latex" ]; then
+      repository="latex"
+    else
+      repository="$MAKE_TARGET"
+    fi
+
+    # Build the specified docker image.
+    PANDOC_VERSION="$version" make $MAKE_TARGET
+  - docker images
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  # TODO: remove/fix this before merging !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  - docker tag pandoc/$repository$colon$version svenevs/$repository$colon$version
+  # ^^^ delete!!
+  # vvv this just becomes pandoc line, tags should already be good from Makefile
+  # NOTE: use `travis_wait` for docker push, otherwise the latex images may not
+  # produce enough output and Travis will think the build has stalled.
+  # - travis_wait 30 docker push svenevs/$repository$colon$version
+  # If specific pandoc release tag, make sure to update `latest` tag.
+  - |
+    if [ "$version" != "edge" ]; then
+      latest="latest"  # a bashism (used after $colon, space not allowed)
+      docker tag pandoc/$repository$colon$version pandoc/$repository$colon$latest
+      # vvv delete!!!
+      docker tag pandoc/$repository$colon$latest svenevs/$repository$colon$latest
+      # ^^^ delete
+      # vvv change to push to pandoc
+      # travis_wait 30 docker push svenevs/$repository$colon$latest
+    fi
+  # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+jobs:
+  include:
+    - stage: Build Alpine Core Image
+      env: MAKE_TARGET="alpine"
+      <<: *build_script
+    - stage: Build Alpine Latex Image
+      env: MAKE_TARGET="alpine-latex"
+      <<: *build_script

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,16 @@ show-args:
 	@printf "pandoc_commit=%s\n" $(PANDOC_COMMIT)
 	@printf "pandoc_citeproc_commit=%s\n" $(PANDOC_CITEPROC_COMMIT)
 
-.PHONY: alpine alpine-tex
+.PHONY: alpine alpine-latex
 alpine:
 	docker build \
 	    --tag pandoc/core:$(PANDOC_VERSION) \
 	    --build-arg pandoc_commit=$(PANDOC_COMMIT) \
 	    --build-arg pandoc_citeproc_commit=$(PANDOC_CITEPROC_COMMIT) \
 	    alpine/
-alpine-tex:
+alpine-latex:
 	docker build \
-	    --tag pandoc/alpine-tex:$(PANDOC_VERSION) \
+	    --tag pandoc/latex:$(PANDOC_VERSION) \
 	    --build-arg base_tag=$(PANDOC_VERSION) \
-	    alpine/tex
+	    alpine/latex
 

--- a/alpine/latex/Dockerfile
+++ b/alpine/latex/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag="master"
+ARG base_tag="edge"
 FROM pandoc/core:${base_tag}
 
 # 1. Install `texlive-full` package, except for `texlive-doc`.  Run
@@ -17,10 +17,16 @@ FROM pandoc/core:${base_tag}
 # 2. Install `libsrvg`, pandoc uses `rsvg-convert` for working with svg images.
 #
 # NOTE: to maintainers, please keep this listing alphabetical.
+# NOTE: piping to `grep Installing` to remedy issues on Travis CI builds.  A job
+# will be terminated if no output for 10 minutes, as well as not being able to
+# see apk progress is frustrating for users.  However, the texlive post-install
+# scripts produce thousands of lines of output, which overflow the travis build
+# log (max 10,000 lines).  This `grep Installing` is a hacky fix for both.
 RUN apk --no-cache add librsvg \
                        texlive \
                        texlive-dvi \
                        texlive-luatex \
                        texlive-xetex \
                        texmf-dist-most \
-                       xdvik
+                       xdvik \
+                       | grep Installing


### PR DESCRIPTION
- [ ] @tarleb add Travis CI github integration to this repository.
- [x] @tarleb add `pandoc/latex` repository and give me push access
- [ ] @svenevs once integrations are setup, use `secret:` key for this repository
    - [ ] @svenevs un-do the `svenevs/*` tags for docker
- [ ] What to do about branches and builds.  I think instead of only building `master`, what we can do is check if the branch being built is master.  Only if branch is `master` do we do `docker push`.  For now I'm just leaving the `docker push` commands commented out.
- [ ] Add description in README of folder structure here vs docker hub image names, protocol for naming of new distributions, etc.
    - [ ] Document how `release=X.Y` in a commit message will produce a build of `<image>:X.Y` release.  Planned strategy is to update README to show available `X.Y` tags on docker hub with a commit message of `release=X.Y`.  These won't happen that frequently, and is easy enough to execute.
- [ ] @tarleb setup monthly cron build for `:edge` to be rolling out hopefully automatically (assuming we don't timeout).