### PR TITLE
build pandoc in parallel

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -29,6 +29,8 @@ RUN git clone --branch=$pandoc_citeproc_commit --depth=1 --quiet \
         https://github.com/jgm/pandoc-citeproc
 
 WORKDIR /usr/src/pandoc
+# NOTE: --ghc-options -j +RTS -A128m -n2m -RTS, see:
+# https://rybczak.net/2016/03/26/how-to-reduce-compilation-times-of-haskell-projects/
 RUN cabal --version \
   && ghc --version \
   && cabal new-update \
@@ -37,7 +39,8 @@ RUN cabal --version \
            --flag embed_data_files \
            --flag bibutils \
            --constraint 'hslua +system-lua +pkg-config' \
-           --ghc-options '-O2 -optc-Os -optl=-pthread -fPIC' . pandoc-citeproc \
+           --ghc-options '-O2 -optc-Os -optl=-pthread -fPIC -j +RTS -A128m -n2m -RTS' \
+           . pandoc-citeproc \
   && cabal new-build . pandoc-citeproc \
   && find dist-newstyle -name 'pandoc*' -type f -perm +400 -exec cp '{}' /usr/bin/ ';'
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -39,7 +39,7 @@ RUN cabal --version \
            --flag embed_data_files \
            --flag bibutils \
            --constraint 'hslua +system-lua +pkg-config' \
-           --ghc-options '-O2 -optc-Os -optl=-pthread -fPIC -j +RTS -A128m -n2m -RTS' \
+           --ghc-options '-O1 -optc-Os -optl=-pthread -fPIC -j +RTS -A128m -n2m -RTS' \
            . pandoc-citeproc \
   && cabal new-build . pandoc-citeproc \
   && find dist-newstyle -name 'pandoc*' -type f -perm +400 -exec cp '{}' /usr/bin/ ';'


### PR DESCRIPTION
Ok so after a lot of digging (and lack of general understanding of haskell tooling `cabal` vs `stack` etc), I did find this article which had good results.  Local build times went from `25` minutes to `20` minutes.  On Travis this diff "maybe" saved 10 minutes.

The Travis time savings are the real motivation because the alpine base image takes between `40` and `48` minutes, which is very close to `50` minute job time limit.

The real problem with the CI right now is #2 specifically the way `cabal` downloads and installs everything.  For some reason on travis that is really slow.  AKA while this did have success, it's in its own PR because it's not exactly necessary and isn't really solving the right problem.  It just happened to actually work as advertised (previously I tried just `-j` which added 10 minutes to local build time).

You know much more about what the implications of this may be, it's not particularly important whether this gets merged or not.  I was trying everything possible to shorten the CI builds, and this one actually worked.  But building pandoc is not the time sync, it's installing the dependencies via `cabal`.  I don't know what to do about that though :slightly_frowning_face: 