### PR TITLE
fix naming inconsistencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,16 @@ show-args:
 	@printf "pandoc_commit=%s\n" $(PANDOC_COMMIT)
 	@printf "pandoc_citeproc_commit=%s\n" $(PANDOC_CITEPROC_COMMIT)
 
-.PHONY: alpine alpine-tex
+.PHONY: alpine alpine-latex
 alpine:
 	docker build \
 	    --tag pandoc/core:$(PANDOC_VERSION) \
 	    --build-arg pandoc_commit=$(PANDOC_COMMIT) \
 	    --build-arg pandoc_citeproc_commit=$(PANDOC_CITEPROC_COMMIT) \
 	    alpine/
-alpine-tex:
+alpine-latex:
 	docker build \
-	    --tag pandoc/alpine-tex:$(PANDOC_VERSION) \
+	    --tag pandoc/latex:$(PANDOC_VERSION) \
 	    --build-arg base_tag=$(PANDOC_VERSION) \
-	    alpine/tex
+	    alpine/latex
 

--- a/alpine/latex/Dockerfile
+++ b/alpine/latex/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag="master"
+ARG base_tag="edge"
 FROM pandoc/core:${base_tag}
 
 # 1. Install `texlive-full` package, except for `texlive-doc`.  Run


### PR DESCRIPTION
- alpine-latex will be uploading to pandoc/latex
- base tag argument should be `edge` not `master` (sorry, that one was my fault!)

Right now you can `PANDOC_VERSION=2.6 make alpine-latex` to test locally, there's no `pandoc/core:edge` pushed yet but that will be fixed soon.

Opening now to merge before CircleCI PR is opened so I don't need to keep gerrymandering that xD