### PR TITLE
reduce latex image size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,15 @@ PANDOC_COMMIT          ?= $(PANDOC_VERSION)
 endif
 include pandoc-citeproc-version.inc.mk
 
+# Used to specify the build context path for Docker.  Note that we are
+# specifying the repository root so that we can
+#
+#     COPY latex-common/texlive.profile /root
+#
+# for example.  If writing a COPY statement in *ANY* Dockerfile, just know that
+# it is from the repository root.
+makefile_dir := $(dir $(realpath Makefile))
+
 # Keep this target first so that `make` with no arguments will print this rather
 # than potentially engaging in expensive builds.
 .PHONY: show-args
@@ -24,12 +33,12 @@ alpine:
 	    --tag pandoc/core:$(PANDOC_VERSION) \
 	    --build-arg pandoc_commit=$(PANDOC_COMMIT) \
 	    --build-arg pandoc_citeproc_commit=$(PANDOC_CITEPROC_COMMIT) \
-	    alpine/
+	    -f $(makefile_dir)/alpine/Dockerfile $(makefile_dir)
 alpine-latex:
 	docker build \
 	    --tag pandoc/latex:$(PANDOC_VERSION) \
 	    --build-arg base_tag=$(PANDOC_VERSION) \
-	    alpine/latex
+	    -f $(makefile_dir)/alpine/latex/Dockerfile $(makefile_dir)
 test-alpine: IMAGE ?= pandoc/core:$(PANDOC_VERSION)
 test-alpine:
 	IMAGE=$(IMAGE) make -C test test-core

--- a/alpine/latex/Dockerfile
+++ b/alpine/latex/Dockerfile
@@ -1,29 +1,27 @@
 ARG base_tag="edge"
 FROM pandoc/core:${base_tag}
 
-# 1. Install `texlive-full` package, except for `texlive-doc`.  Run
-#    `apk -R info texlive-full` to see dependencies.  However, to help reduce
-#    the image size, instead of `texmf-dist-full` we choose `texmf-dist-most`.
-#    Users seeking Chinese, Cyrillic, Greek, Japanese, or Korean should install
-#    these packages (`texmf-dist-langchinese` for example), or install the
-#    wrapper package `texmf-dist-lang`.  This saves approximately 800MB, so we
-#    ask that users who need a specific language install it directly.
-#
-#    For an in-depth understanding of what options are available, see the
-#    package specification here:
-#
-#        https://git.alpinelinux.org/aports/tree/community/texmf-dist/APKBUILD
-#
-# 2. Install `libsrvg`, pandoc uses `rsvg-convert` for working with svg images.
-#
+# NOTE: `libsrvg`, pandoc uses `rsvg-convert` for working with svg images.
 # NOTE: to maintainers, please keep this listing alphabetical.
-RUN apk --no-cache add librsvg \
-                       texlive \
-                       texlive-dvi \
-                       texlive-luatex \
-                       texlive-xetex \
-                       texmf-dist-most \
-                       xdvik \
-                       | grep 'Installing'
-# NOTE: `grep 'Installing'` is to suppress latex post-install scripts from
-# flooding the CI buffer.
+RUN apk --no-cache add \
+        freetype \
+        fontconfig \
+        gnupg \
+        gzip \
+        librsvg \
+        perl \
+        tar \
+        wget
+
+# DANGER: this will vary for different distributions, particularly the
+# `linuxmusl` suffix.  Alpine linux is a musl libc based distribution, for other
+# "more common" distributions, you likely want just `-linux` suffix rather than
+# `-linuxmusl` -----------------> vvvvvvvvvvvvvvvv
+ENV PATH="/opt/texlive/texdir/bin/x86_64-linuxmusl:${PATH}"
+WORKDIR /root
+COPY latex-common/texlive.profile /root/texlive.profile
+COPY latex-common/install-texlive.sh /root/install-texlive.sh
+RUN /root/install-texlive.sh
+RUN rm -f /root/texlive.profile /root/install-texlive.sh
+
+WORKDIR /data

--- a/alpine/latex/Dockerfile
+++ b/alpine/latex/Dockerfile
@@ -19,9 +19,16 @@ RUN apk --no-cache add \
 # `-linuxmusl` -----------------> vvvvvvvvvvvvvvvv
 ENV PATH="/opt/texlive/texdir/bin/x86_64-linuxmusl:${PATH}"
 WORKDIR /root
+
 COPY latex-common/texlive.profile /root/texlive.profile
 COPY latex-common/install-texlive.sh /root/install-texlive.sh
 RUN /root/install-texlive.sh
-RUN rm -f /root/texlive.profile /root/install-texlive.sh
+
+COPY latex-common/install-tex-packages.sh /root/install-tex-packages.sh
+RUN /root/install-tex-packages.sh
+
+RUN rm -f /root/texlive.profile \
+          /root/install-texlive.sh \
+          /root/install-tex-packages.sh
 
 WORKDIR /data

--- a/latex-common/install-tex-packages.sh
+++ b/latex-common/install-tex-packages.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+################################################################################
+# Install pandoc latex pacakges: https://pandoc.org/MANUAL.html#creating-a-pdf #
+################################################################################
+# NOTE: search left hand side on CTAN to see for yourself:
+#       graphicx  -> graphics
+#       grffile   -> oberdiek
+#       longtable -> tools
+tlmgr install amsfonts \
+              amsmath \
+              babel \
+              booktabs \
+              fancyvrb \
+              geometry \
+              graphics \
+              hyperref \
+              ifluatex \
+              ifxetex \
+              listings \
+              lm \
+              lm-math \
+              oberdiek \
+              setspace \
+              tools \
+              ulem \
+              unicode-math \
+              xcolor \
+              || exit 1
+
+################################################################################
+# Install extra packages for XeTex, LuaTex, and BibLaTex.                      #
+################################################################################
+tlmgr install bidi \
+              csquotes \
+              fontspec \
+              luatex \
+              lualatex-math \
+              mathspec \
+              microtype \
+              polyglossia \
+              upquote \
+              xecjk \
+              xetex \
+              || exit 1
+
+# Make sure all reference backend options are installed
+tlmgr install biber \
+              biblatex \
+              bibtex \
+              natbib \
+              || exit 1
+
+# These packages were identified by the tests, they are likely dependencies of
+# dependencies that are not encoded well.
+tlmgr install footnotehyper \
+              xurl \
+              || exit 1
+
+################################################################################
+# Trim down (possibly large amounts of) installed artifacts such as docs.      #
+################################################################################
+rm -rf /opt/texlive/texdir/texmf-dist/doc  \
+       /opt/texlive/texdir/readme-html.dir \
+       /opt/texlive/texdir/readme-txt.dir  \
+       /opt/texlive/texdir/install-tl*

--- a/latex-common/install-texlive.sh
+++ b/latex-common/install-texlive.sh
@@ -1,66 +1,12 @@
 #!/bin/sh
 
-################################################################################
-# Download / extract the install-tl perl script.                               #
-################################################################################
+# Download / extract the install-tl perl script.
 wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz || exit 1
 mkdir -p ./install-tl
 tar --strip-components 1 -zvxf install-tl-unx.tar.gz -C "$PWD/install-tl" || exit 1
 
-################################################################################
-# Run the default installation with the specified profile.                     #
-################################################################################
+# Run the default installation with the specified profile.
 ./install-tl/install-tl --profile=/root/texlive.profile
 
-################################################################################
-# Install pandoc latex pacakges: https://pandoc.org/MANUAL.html#creating-a-pdf #
-################################################################################
-# NOTE: graphicx, grffile, and longtable appear to be default packages?  tlmgr
-#       cannot install them and will error out. That is why they are excluded.
-tlmgr install amsfonts     \
-              amsmath      \
-              lm           \
-              lm-math      \
-              unicode-math \
-              ifxetex      \
-              ifluatex     \
-              listings     \
-              fancyvrb     \
-              booktabs     \
-              hyperref     \
-              xcolor       \
-              ulem         \
-              geometry     \
-              setspace     \
-              babel
-
-################################################################################
-# Install extra packages for XeTex, LuaTex, and BibLaTex.                      #
-################################################################################
-tlmgr install xetex       \
-              luatex      \
-              fontspec    \
-              polyglossia \
-              xecjk       \
-              bidi        \
-              mathspec    \
-              upquote     \
-              microtype   \
-              csquotes    \
-              lualatex-math
-
-# Make sure all reference backend options are installed
-tlmgr install natbib   \
-              biblatex \
-              bibtex   \
-              biber
-
-################################################################################
-# Trim down (possibly large amounts of) installed artifacts such as docs.      #
-################################################################################
-rm -rf ./install-tl                        \
-       ./install-tl-unx.tar.gz             \
-       /opt/texlive/texdir/texmf-dist/doc  \
-       /opt/texlive/texdir/readme-html.dir \
-       /opt/texlive/texdir/readme-txt.dir  \
-       /opt/texlive/texdir/install-tl*
+# Cleanup installation artifacts.
+rm -rf ./install-tl ./install-tl-unx.tar.gz

--- a/latex-common/install-texlive.sh
+++ b/latex-common/install-texlive.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+################################################################################
+# Download / extract the install-tl perl script.                               #
+################################################################################
+wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz || exit 1
+mkdir -p ./install-tl
+tar --strip-components 1 -zvxf install-tl-unx.tar.gz -C "$PWD/install-tl" || exit 1
+
+################################################################################
+# Run the default installation with the specified profile.                     #
+################################################################################
+./install-tl/install-tl --profile=/root/texlive.profile
+
+################################################################################
+# Install pandoc latex pacakges: https://pandoc.org/MANUAL.html#creating-a-pdf #
+################################################################################
+# NOTE: graphicx, grffile, and longtable appear to be default packages?  tlmgr
+#       cannot install them and will error out. That is why they are excluded.
+tlmgr install amsfonts     \
+              amsmath      \
+              lm           \
+              lm-math      \
+              unicode-math \
+              ifxetex      \
+              ifluatex     \
+              listings     \
+              fancyvrb     \
+              booktabs     \
+              hyperref     \
+              xcolor       \
+              ulem         \
+              geometry     \
+              setspace     \
+              babel
+
+################################################################################
+# Install extra packages for XeTex, LuaTex, and BibLaTex.                      #
+################################################################################
+tlmgr install xetex       \
+              luatex      \
+              fontspec    \
+              polyglossia \
+              xecjk       \
+              bidi        \
+              mathspec    \
+              upquote     \
+              microtype   \
+              csquotes    \
+              lualatex-math
+
+# Make sure all reference backend options are installed
+tlmgr install natbib   \
+              biblatex \
+              bibtex   \
+              biber
+
+################################################################################
+# Trim down (possibly large amounts of) installed artifacts such as docs.      #
+################################################################################
+rm -rf ./install-tl                        \
+       ./install-tl-unx.tar.gz             \
+       /opt/texlive/texdir/texmf-dist/doc  \
+       /opt/texlive/texdir/readme-html.dir \
+       /opt/texlive/texdir/readme-txt.dir  \
+       /opt/texlive/texdir/install-tl*

--- a/latex-common/texlive.profile
+++ b/latex-common/texlive.profile
@@ -1,0 +1,30 @@
+# texlive.profile written on Tue Feb  5 09:43:07 2019 UTC
+# It will NOT be updated and reflects only the
+# installation profile at installation time.
+selected_scheme scheme-small
+TEXDIR         /opt/texlive/texdir
+TEXMFLOCAL     /opt/texlive/texmf-local
+TEXMFSYSVAR    /opt/texlive/texdir/texmf-var
+TEXMFSYSCONFIG /opt/texlive/texdir/texmf-config
+TEXMFVAR       ~/.texlive/texmf-var
+TEXMFCONFIG    ~/.texlive/texmf-config
+TEXMFHOME      ~/texmf
+binary_x86_64-linuxmusl 1
+instopt_adjustpath 0
+instopt_adjustrepo 1
+instopt_letter 0
+instopt_portable 0
+instopt_write18_restricted 1
+tlpdbopt_autobackup 1
+tlpdbopt_backupdir tlpkg/backups
+tlpdbopt_create_formats 1
+tlpdbopt_desktop_integration 1
+tlpdbopt_file_assocs 1
+tlpdbopt_generate_updmap 0
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0
+tlpdbopt_post_code 1
+tlpdbopt_sys_bin /usr/local/bin
+tlpdbopt_sys_info /usr/local/share/info
+tlpdbopt_sys_man /usr/local/share/man
+tlpdbopt_w32_multi_user 1


### PR DESCRIPTION
New PR (supersedes #14) for CI to run now that we have tests!

Fixes #5.

- [x] verify all tests succeed / the hidden tex dependencies are found (as best as we can find them)
- [x] delete original `reduce-latex-size` branch once this merges (rebase / merge creates lots of conflicts, easier to keep around for track record until not needed)