### PR TITLE
make sure CI test targets test same PANDOC_VERSION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,9 @@ jobs:
             ./.circleci/build_image.sh << parameters.core_target >>
       # Test core image
       - run:
-          command: 'make test-<< parameters.core_target >>'
+          command: |
+            version="$(./.circleci/version_for_commit_message.sh)"
+            PANDOC_VERSION="$version" make test-<< parameters.core_target >>
       # After that is complete, now build the latex image.
       - run:
           # Set a 1 hour time limit.  Build/push may get silent during parts.
@@ -49,7 +51,9 @@ jobs:
             ./.circleci/build_image.sh << parameters.latex_target >>
       # Test latex image
       - run:
-          command: 'make test-<< parameters.latex_target >>'
+          command: |
+            version="$(./.circleci/version_for_commit_message.sh)"
+            PANDOC_VERSION="$version" make test-<< parameters.latex_target >>
 
 # We need to be able to distinguish cron jobs, something that CircleCI does not
 # currently support in their default environment variables.  Defining all image

--- a/.circleci/version_for_commit_message.sh
+++ b/.circleci/version_for_commit_message.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Determine PANDOC_VERSION for Makefile based on commit message.  We are looking
+# for if the string `release=X.Y` exists, if so then that is what we are going
+# to build.  Otherwise, build the `master` branch (which is the `edge` image).
+# NOTE: cron jobs always build the :edge tag.
+release_tag="$(git log --pretty="%s" -1 | grep -o 'release=[0-9]\.[0-9]')"
+if [[ "$CIRCLE_CRON_JOB" == "true" ]] || [[ -z "$release_tag" ]]; then
+    version="edge"
+else
+    version="$(echo "$release_tag" | cut -d = -f 2)"
+fi
+
+# Scripts calling this expect the output on stdout.
+echo "$version"


### PR DESCRIPTION
Fixes #25.

- [x] manually verify first commit tests `edge`
- [x] manually verify dummy `release=2.5` commit builds / tests 2.5
- [x] force push away `release=2.5` commit, merge with `[ci skip]` to not waste time, post-merge an immediate `release=2.6` PR will be created.