### PR TITLE
WIP: add biber to LaTeX image

### DIFF
--- a/alpine/latex/Dockerfile
+++ b/alpine/latex/Dockerfile
@@ -4,6 +4,7 @@ FROM pandoc/core:${base_tag}
 # NOTE: `libsrvg`, pandoc uses `rsvg-convert` for working with svg images.
 # NOTE: to maintainers, please keep this listing alphabetical.
 RUN apk --no-cache add \
+        biber \
         freetype \
         fontconfig \
         gnupg \

--- a/latex-common/install-tex-packages.sh
+++ b/latex-common/install-tex-packages.sh
@@ -19,6 +19,7 @@ tlmgr install amsfonts \
               listings \
               lm \
               lm-math \
+              logreq \
               oberdiek \
               setspace \
               tools \

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,7 +53,7 @@ LATEX_CMD = docker run --rm -it \
 .PHONY: test-latex
 test-latex: output/testsuite.pdf output/french.pdf output/german.pdf \
 		output/lorem-geometry.pdf output/lorem-optional-packages.pdf \
-		output/test-beamer.pdf
+		output/test-beamer.pdf output/test-natbib.pdf output/test-biblatex.pdf
 
 output/testsuite.pdf: testsuite.native
 	$(LATEX_CMD) $< \
@@ -88,6 +88,33 @@ output/test-beamer.pdf: test-beamer.md example.bib
 	    --to=beamer \
 	    --bibliography=example.bib \
 	    --pdf-engine=xelatex
+
+output/test-natbib.pdf: test-beamer.md example.bib
+	$(LATEX_CMD) $< \
+	    --natbib \
+	    --output=$@ \
+	    --bibliography=example.bib \
+	    --pdf-engine=xelatex
+
+output/test-biblatex.tex: test-beamer.md
+	$(LATEX_CMD) $< \
+	    --biblatex \
+	    --standalone \
+	    --bibliography=example.bib \
+	    --output=$@
+
+output/example.bib: example.bib
+	cp $< $@
+
+output/baboon.png: baboon.png
+	cp $< $@
+
+output/test-biblatex.pdf: output/test-biblatex.tex output/example.bib \
+		output/baboon.png
+	docker run --rm -it -v $(test_files_path):/data \
+	    --entrypoint=/data/pdf-via-biblatex.sh \
+	    $(IMAGE) \
+	    $(notdir $(basename $<))
 
 #   ____ _
 #  / ___| | ___  __ _ _ __

--- a/test/pdf-via-biblatex.sh
+++ b/test/pdf-via-biblatex.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+cd output
+xelatex $1
+biber $1
+xelatex $1
+xelatex $1


### PR DESCRIPTION
A version mismatch between biber and xelatex prevents this from working right now.