### PR TITLE
fix biber / biblatex problems specific to alpine

### DIFF
--- a/alpine/latex/Dockerfile
+++ b/alpine/latex/Dockerfile
@@ -31,4 +31,52 @@ RUN rm -f /root/texlive.profile \
           /root/install-texlive.sh \
           /root/install-tex-packages.sh
 
+################################################################################
+# NOTE: this is only necessary for Alpine latex, right now `tlmgr install biber`
+# does not work because the musl c binaries are not available.  This will change
+# in the future thanks to @krumeich.  We also cannot `apk add biber` because the
+# hosted version is incompatible with the LaTeX we install.  See
+# https://github.com/plk/biber/issues/255
+RUN \
+  wget --quiet https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/development/binaries/Linux-musl/biber-linux_x86_64-musl.tar.gz \
+  && tar -xf biber-linux_x86_64-musl.tar.gz \
+  && mv biber-linux_x86_64-musl /opt/texlive/texdir/bin/x86_64-linuxmusl/biber \
+  && rm -f biber-linux_x86_64-musl.tar.gz \
+  # biblatex and biber versions are tightly coupled, in the future we will be able
+  # to just `tlmgr install biber biblatex` as done in install-tex-packages.sh, but
+  # for now we are going to just manually overwrite them.  The idea being that in
+  # the future when this all hits public facing archives, we can just delete this
+  # block of code entirely without modifying install-tex-packages.sh :)
+  && tlmgr uninstall --no-depends biblatex \
+  # tlmgr backs up uninstall, no need to keep it around
+  && rm -rf /opt/texlive/texdir/tlpkg/backups/* \
+  && wget --quiet https://downloads.sourceforge.net/project/biblatex/development/biblatex-3.13.tgz \
+  && tar -xf biblatex-3.13.tgz \
+  && rm biblatex-3.13.tgz \
+  && cd /root/biblatex \
+  # Inlined from README, MANUAL installation method.
+  # 3. Copy all files and subdirectories in the 'latex' directory to:
+  #    <texmflocal>/tex/latex/biblatex/
+  && mv latex /opt/texlive/texmf-local/tex/latex/biblatex \
+  # 4. Copy all files in the 'bibtex/bst' subdirectory to:
+  #    <texmflocal>/bibtex/bst/biblatex/
+  && mv bibtex/bst /opt/texlive/texmf-local/bibtex/bst/biblatex \
+  # 5. Copy all files in the 'bibtex/bib' subdirectory to:
+  #    <texmflocal>/bibtex/bib/biblatex/
+  && mv bibtex/bib /opt/texlive/texmf-local/bibtex/bib/biblatex \
+  # 6. If you are using bibtex8, copy all files in the 'bibtex/csf'
+  #    subdirectory to:
+  #    <texmflocal>/bibtex/csf/biblatex/
+  # ---> bibtex/csf directory does not exist.
+  # 7. The manual and example files in 'doc' subdirectory go to
+  #    <texmflocal>/doc/latex/biblatex/
+  # --> we skip this to reduce image size
+  # 8. Update the file hash tables (also known as the file name database).
+  #    On teTeX and TeX Live systems, run texhash as root ('sudo texhash').
+  && texhash \
+  # Delete remaining components of biblatex extract
+  && cd /root \
+  && rm -rf biblatex*
+################################################################################
+
 WORKDIR /data

--- a/latex-common/install-tex-packages.sh
+++ b/latex-common/install-tex-packages.sh
@@ -19,6 +19,7 @@ tlmgr install amsfonts \
               listings \
               lm \
               lm-math \
+              logreq \
               oberdiek \
               setspace \
               tools \

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,7 +53,7 @@ LATEX_CMD = docker run --rm -it \
 .PHONY: test-latex
 test-latex: output/testsuite.pdf output/french.pdf output/german.pdf \
 		output/lorem-geometry.pdf output/lorem-optional-packages.pdf \
-		output/test-beamer.pdf
+		output/test-beamer.pdf output/test-natbib.pdf output/test-biblatex.pdf
 
 output/testsuite.pdf: testsuite.native
 	$(LATEX_CMD) $< \
@@ -88,6 +88,33 @@ output/test-beamer.pdf: test-beamer.md example.bib
 	    --to=beamer \
 	    --bibliography=example.bib \
 	    --pdf-engine=xelatex
+
+output/test-natbib.pdf: test-beamer.md example.bib
+	$(LATEX_CMD) $< \
+	    --natbib \
+	    --output=$@ \
+	    --bibliography=example.bib \
+	    --pdf-engine=xelatex
+
+output/test-biblatex.tex: test-beamer.md
+	$(LATEX_CMD) $< \
+	    --biblatex \
+	    --standalone \
+	    --bibliography=example.bib \
+	    --output=$@
+
+output/example.bib: example.bib
+	cp $< $@
+
+output/baboon.png: baboon.png
+	cp $< $@
+
+output/test-biblatex.pdf: output/test-biblatex.tex output/example.bib \
+		output/baboon.png
+	docker run --rm -it -v $(test_files_path):/data \
+	    --entrypoint=/data/pdf-via-biblatex.sh \
+	    $(IMAGE) \
+	    $(notdir $(basename $<))
 
 #   ____ _
 #  / ___| | ___  __ _ _ __

--- a/test/pdf-via-biblatex.sh
+++ b/test/pdf-via-biblatex.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+cd output
+xelatex "$1"
+biber "$1"
+xelatex "$1"
+xelatex "$1"


### PR DESCRIPTION
Fixes #27.  Supersedes #28 (see that thread for details).

- [x] Add tests that break the latex image.
- [ ] Fix latex image for alpine specific problems by installing newly packaged dev binaries and corresponding biblatex version.
- [x] Wait until `pandoc:master` can build again.