### PR TITLE
pandoc sets pandoc-citeproc version in cabal.project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ PANDOC_COMMIT          ?= master
 else
 PANDOC_COMMIT          ?= $(PANDOC_VERSION)
 endif
-include pandoc-citeproc-version.inc.mk
 
 # Used to specify the build context path for Docker.  Note that we are
 # specifying the repository root so that we can
@@ -22,7 +21,6 @@ makefile_dir := $(dir $(realpath Makefile))
 show-args:
 	@printf "PANDOC_VERSION (i.e. image version tag): %s\n" $(PANDOC_VERSION)
 	@printf "pandoc_commit=%s\n" $(PANDOC_COMMIT)
-	@printf "pandoc_citeproc_commit=%s\n" $(PANDOC_CITEPROC_COMMIT)
 
 ################################################################################
 # Alpine images and tests                                                      #
@@ -32,7 +30,6 @@ alpine:
 	docker build \
 	    --tag pandoc/core:$(PANDOC_VERSION) \
 	    --build-arg pandoc_commit=$(PANDOC_COMMIT) \
-	    --build-arg pandoc_citeproc_commit=$(PANDOC_CITEPROC_COMMIT) \
 	    -f $(makefile_dir)/alpine/Dockerfile $(makefile_dir)
 alpine-latex:
 	docker build \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,13 +20,10 @@ RUN cabal update \
 
 FROM alpine-pandoc-haskell AS alpine-pandoc-build
 ARG pandoc_commit=master
-ARG pandoc_citeproc_commit=master
 
 WORKDIR /usr/src/
 RUN git clone --branch=$pandoc_commit --depth=1 --quiet \
         https://github.com/jgm/pandoc
-RUN git clone --branch=$pandoc_citeproc_commit --depth=1 --quiet \
-        https://github.com/jgm/pandoc-citeproc
 
 WORKDIR /usr/src/pandoc
 # NOTE: --ghc-options -j +RTS -A128m -n2m -RTS, see:
@@ -49,12 +46,10 @@ RUN strip /usr/bin/pandoc /usr/bin/pandoc-citeproc
 
 FROM alpine AS alpine-pandoc
 ARG pandoc_commit=master
-ARG pandoc_citeproc_commit=master
 LABEL maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'
 LABEL org.pandoc.maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'
 LABEL org.pandoc.author "John MacFarlane"
 LABEL org.pandoc.version "$pandoc_commit"
-LABEL org.pandoc.pandoc-citeproc.version "$pandoc_citeproc_commit"
 
 COPY --from=alpine-pandoc-build /usr/bin/pandoc* /usr/bin/
 RUN apk update \

--- a/pandoc-citeproc-version.inc.mk
+++ b/pandoc-citeproc-version.inc.mk
@@ -1,9 +1,0 @@
-ifeq ($(PANDOC_VERSION),2.6)
-PANDOC_CITEPROC_COMMIT ?= 0.15.0.1
-endif
-ifeq ($(PANDOC_VERSION),2.7)
-PANDOC_CITEPROC_COMMIT ?= 0.16.1.1
-endif
-
-# Use pandoc-citeproc master per default
-PANDOC_CITEPROC_COMMIT ?= master


### PR DESCRIPTION
Follow-up to https://github.com/pandoc/dockerfiles/pull/32#issuecomment-471222041

- [x] Test if it actually works (thankfully we already have `pandoc-citeproc` tests! :heart:)
- [x] Confirm this is actually a good thing to do
    - [x] If approved, upstream to `pandoc`'s `Dockerfile`.

Right now we clone but (as far as I can tell) don't actually use the cloned `pandoc-citeproc`.