### PR TITLE
Leave it to users to mount `/data` as volume

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -59,5 +59,4 @@ RUN apk update \
          lua5.3
 
 WORKDIR /data
-VOLUME ["/data"]
 ENTRYPOINT ["pandoc"]


### PR DESCRIPTION
Marking `/data` as a volume within the Dockerfile is problematic, as it
makes it more difficult to use the container within another Dockerfile,
as any data written to that directory will not be part of the new image.

E.g., a user might want to convert a doc while building a container,
like so:

    FROM ... as builder
    # build app

    FROM pandoc/core:latest as docs
    COPY doc/mydoc.md /data/mydoc.md
    RUN pandoc mydoc.md --output /data/mydoc.docx

    FROM ...
    # setup runtime
    COPY --from=docs /data/mydoc.docx /app/mydoc.docx
    ...

This did not work previously, as `/data` was mounted as an anonymous
volume in *docs*. Thus all data written to it did not become part of
the image, and the final `COPY --from=docs` would not have worked.

Users will usually create a volume in that location via the command
line – interactive use of the container should therefor be unaffected.