### PR TITLE
Use smarter entrypoint script

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -53,6 +53,7 @@ LABEL org.pandoc.author "John MacFarlane"
 LABEL org.pandoc.version "$pandoc_commit"
 
 COPY --from=pandoc-binaries /usr/bin/pandoc* /usr/bin/
+COPY common/docker-entrypoint.sh /usr/local/bin
 RUN apk add --no-cache \
          gmp \
          libffi \
@@ -60,4 +61,4 @@ RUN apk add --no-cache \
          lua5.3-lpeg
 
 WORKDIR /data
-ENTRYPOINT ["pandoc"]
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Partially taken from the node image entrypoint script.
+# See <https://github.com/nodejs/docker-node>
+
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+  set -- pandoc "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The entrypoint script makes it easier to call other executables in the
image: it checks whether the first command is a command, and if it is,
that command is run. Otherwise, pandoc will be called, as it was before.

Closes: #54