### PR TITLE
Fixes missing tex packages

### DIFF
--- a/common/latex/install-tex-packages.sh
+++ b/common/latex/install-tex-packages.sh
@@ -14,8 +14,7 @@ tlmgr install amsfonts \
               geometry \
               graphics \
               hyperref \
-              ifluatex \
-              ifxetex \
+              iftex \
               listings \
               lm \
               lm-math \


### PR DESCRIPTION
The packages 'ifluatex' and 'ifxetex' are no longer available, and thus
the build fails

    tlmgr install: package ifluatex not present in repository.
    tlmgr install: package ifxetex not present in repository.

Both packages can be found in package 'iftex', see

    https://ctan.org/pkg/ifluatex
    https://ctan.org/pkg/ifxetex