### PR TITLE
simplify actions usage: use container directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,14 @@ so you must include the command.
 GitHub Actions
 --------------------------------------------------------------------------------
 
-GitHub Actions is an Infrastructure as a Service (IaaS) from GitHub, that allows
+GitHub Actions is an Infrastructure as a Service (IaaS) from GitHub that allows
 you to automatically run code on GitHub's servers on every push (or a bunch of
-other GitHub events). For example, you can use GitHub Actions to convert some
-`file.md` in your git source to `file.pdf` (via LaTeX) using pandoc and upload
- the results to a web host.
+other GitHub events).
+
+ Such continuous integration and delivery (CI/CD) may be useful for many pandoc
+ users. Perhaps, you're using pandoc convert some markdown source document into HTML and deploy the results to a webserver. If the source document is under
+ version control (such as git), you might want pandoc to convert and deploy
+ *on every commit*. That is what CI/CD does.
 
 To use pandoc on GitHub Actions, you can leverage the docker images of this
 project.

--- a/README.md
+++ b/README.md
@@ -173,26 +173,18 @@ so you must include the command.
 GitHub Actions
 --------------------------------------------------------------------------------
 
-By encapsulating the compute environment, Docker can make it easier to run
-dependency-heavy software on your local machine, but it was designed to run in
-the cloud.
+GitHub Actions is an Infrastructure as a Service (IaaS) from GitHub, that allows
+you to automatically run code on GitHub's servers on every push (or a bunch of
+other GitHub events). For example, you can use GitHub Actions to convert some
+`file.md` in your git source to `file.pdf` (via LaTeX) using pandoc and upload
+ the results to a web host.
 
-Continuous integration and delivery (CI/CD) is a cloud service that may be
-useful for many pandoc users. Perhaps, you're using pandoc convert some markdown
-source document into HTML and deploy the results to a webserver. If the source
-document is under version control (such as git), you might want pandoc to
-convert and deploy *on every commit*. That is what CI/CD does.
+To use pandoc on GitHub Actions, you can leverage the docker images of this
+project.
 
-You can use the above docker images on any number of CI/CD services; many will
-accept arbitrary docker container.
-
-GitHub actions is a relatively new workflow automation feature from the popular
-git host GitHub. Docker containers are especially easy to use on GitHub actions.
-
-GitHub actions can also be packaged, published and reused as "plug-and-play"
-workflows. There is already a [pandoc GitHub
-action](https://github.com/maxheld83/pandoc) that lets you use the pandoc docker
-images inside of GitHub actions.
+To learn more how to use the docker pandoc images in your GitHub Actions
+workflow, see
+[these examples](http://github.com/maxheld83/pandoc-action-example).
 
 
 Maintenance Notes


### PR DESCRIPTION
GitHub Actions now *directly* supports container actions (it might have done that for some time, and I might have missed it).
Either way, there is no good reason for keeping my [github action](https://github.com/maxheld83/pandoc-action); it only adds a useless layer.
I have therefore soft-deprecated it; it will continue to work, but new users shouldn't use it.

Instead, I've created a few [examples](https://github.com/maxheld83/pandoc-action-example) that people can model their usage on.

This PR reflects these changes.
I've also removed the explanation of what GitHub Action is/does; that seems to be out of scope.

The examples I wrote might be too long for the documentation *here*, so I think it's best to link to a separate repo (which I'd love to migrate to your org as per https://github.com/maxheld83/pandoc-action-example/issues/1).

The examples also all get run on every commit, so we can be sure they work.