### PR TITLE
Run first command only if it is executable

### DIFF
--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+if [ "${1#-}" != "${1}" ] || [ ! -x "$(command -v "${1}")" ]; then
   set -- pandoc "$@"
 fi
 


### PR DESCRIPTION
This works around a short-coming of `command` built into `ash`, which
behaves weirdly if the argument to `command -v` is an existing file in a
subdirectory.