### PR TITLE
unify make / docker tag targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ show-args:
 	@printf "# usually a tag or branch name.\n"
 	@printf "PANDOC_COMMIT=%s\n" $(PANDOC_COMMIT)
 
+# TODO: alpine
 # image_stacks = alpine \
 #                ubuntu
 image_stacks = ubuntu

--- a/test/Makefile
+++ b/test/Makefile
@@ -36,7 +36,7 @@ testsuite-to-%: testsuite.native
 
 test-bib-conversion: example.bib
 	docker run --rm -it -v $(test_files_path):/data \
-	    --entrypoint=/usr/bin/pandoc-citeproc $(IMAGE) \
+	    --entrypoint=/usr/local/bin/pandoc-citeproc $(IMAGE) \
 	    --bib2yaml $< > /dev/null
 
 test-lua: testsuite.native lpeg-test.lua

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -58,7 +58,7 @@ RUN find dist-newstyle \
 # Cabal's exec stripping doesn't seem to work reliably, let's do it here.
 RUN strip /usr/local/bin/pandoc*
 
-FROM ubuntu:focal AS focal-pandoc
+FROM ubuntu:focal AS pandoc-core
 ARG pandoc_version=edge
 LABEL maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'
 LABEL org.pandoc.maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'
@@ -85,7 +85,7 @@ RUN apt-get -q --no-allow-insecure-repositories update \
 WORKDIR /data
 ENTRYPOINT ["/usr/local/bin/pandoc"]
 
-FROM focal-pandoc AS focal-pandoc-crossref
+FROM pandoc-core AS pandoc-core-crossref
 COPY --from=ubuntu-builder \
   /usr/local/bin/pandoc-crossref \
   /usr/local/bin/


### PR DESCRIPTION
- Alpine stack ready to be converted.
- Fix testing path /usr/local/bin/
- Use same --target pandoc-core name for all image stacks
  (generative targets in make). [ci skip]

Closes #90 to `master`.  Going to push a test `release=2.9.2.1` commit message, DO NOT MERGE THIS WITH THAT IN THERE! (Squash and reword to delete `release` tag).