### PR TITLE
remove CircleCI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 pandoc Dockerfiles
 ================================================================================
 
-[![CircleCI](https://circleci.com/gh/pandoc/dockerfiles/tree/master.svg?style=svg)](https://circleci.com/gh/pandoc/dockerfiles/tree/master)
-
 This repo contains a collection of Dockerfiles to build various
 [pandoc](https://pandoc.org/) container images.
 


### PR DESCRIPTION
Missed this in the CircleCI cleanup.

Are you able to remove CircleCI builds from this repo?  All PRs / branch builds will keep failing until it is revoked xD