### PR TITLE
Add selnolig to install-tex-packages.sh

### DIFF
--- a/common/latex/install-tex-packages.sh
+++ b/common/latex/install-tex-packages.sh
@@ -42,6 +42,7 @@ tlmgr install bidi \
               microtype \
               pdftexcmds \
               polyglossia \
+              selnolig \
               upquote \
               xecjk \
               xetex \


### PR DESCRIPTION
selnolig is required for lualatex support (https://pandoc.org/MANUAL.html#creating-a-pdf).

This allows the `pdf-engine --lualatex` option.