### PR TITLE
Using Alpine 3.14 instead of Alpine 3.12

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Base #########################################################################
-FROM alpine:3.12 AS alpine-builder-base
+FROM alpine:3.14 AS alpine-builder-base
 WORKDIR /app
 
 RUN apk --no-cache add \
@@ -57,7 +57,7 @@ RUN find dist-newstyle \
          -exec cp '{}' /usr/local/bin/ ';'
 
 # Core #########################################################################
-FROM alpine:3.12 AS alpine-core
+FROM alpine:3.14 AS alpine-core
 ARG pandoc_version=edge
 LABEL maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'
 LABEL org.pandoc.maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'


### PR DESCRIPTION
Hi
I needed some latex packages that have been introduced since Alpine 3.13. At this time, 3.14 is the latest Alpine release.
Hence I changed the alpine Dockerfile to use the latest version.

I hope this can be introduced along the next release of pandoc