### PR TITLE
add CORES argument for docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PANDOC_VERSION ?= edge
-THREADS        ?= 2
+CORES        ?= 2
 
 ifeq ($(PANDOC_VERSION),edge)
 PANDOC_COMMIT          ?= master
@@ -59,7 +59,7 @@ show-args:
 	@printf "# WITHOUT_CROSSREF; not intended to be set directly.\n"
 	@printf "extra_packages=%s\n" "$(extra_packages)"
 	@printf "\n# Controls the number of threads to be used during the build process\n"
-	@printf "THREADS=%s\n" $(THREADS)
+	@printf "CORES=%s\n" $(CORES)
 
 # Generates the targets for a given image stack.
 # $1: base stack, one of the `supported_stacks`
@@ -96,7 +96,7 @@ freeze-file: $(STACK)/$(stack_freeze_file)
 %/$(stack_freeze_file): common/pandoc-freeze.sh
 	docker build \
 		--cpu-period="100000" \
-		--cpu-quota="$$(( $(THREADS) * 100000 ))" \
+		--cpu-quota="$$(( $(CORES) * 100000 ))" \
 		--tag pandoc/$(STACK)-builder-base \
 		--target=$(STACK)-builder-base \
 		-f $(makefile_dir)/$(STACK)/Dockerfile $(makefile_dir)
@@ -110,7 +110,7 @@ freeze-file: $(STACK)/$(stack_freeze_file)
 core:
 	docker build \
 		--cpu-period="100000" \
-		--cpu-quota="$$(( $(THREADS) * 100000 ))" \
+		--cpu-quota="$$(( $(CORES) * 100000 ))" \
 		--tag pandoc/$(STACK):$(PANDOC_VERSION) \
 		--build-arg pandoc_commit=$(PANDOC_COMMIT) \
 		--build-arg pandoc_version=$(PANDOC_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PANDOC_VERSION ?= edge
+THREADS        ?= 2
 
 ifeq ($(PANDOC_VERSION),edge)
 PANDOC_COMMIT          ?= master
@@ -57,6 +58,8 @@ show-args:
 	@printf "\n# Additional packages build alongside pandoc. Controlled via\n"
 	@printf "# WITHOUT_CROSSREF; not intended to be set directly.\n"
 	@printf "extra_packages=%s\n" "$(extra_packages)"
+	@printf "\n# Controls the number of threads to be used during the build process\n"
+	@printf "THREADS=%s\n" $(THREADS)
 
 # Generates the targets for a given image stack.
 # $1: base stack, one of the `supported_stacks`
@@ -92,6 +95,8 @@ freeze-file: $(STACK)/$(stack_freeze_file)
 %/$(stack_freeze_file): STACK = $*
 %/$(stack_freeze_file): common/pandoc-freeze.sh
 	docker build \
+		--cpu-period="100000" \
+		--cpu-quota="$$(( $(THREADS) * 100000 ))" \
 		--tag pandoc/$(STACK)-builder-base \
 		--target=$(STACK)-builder-base \
 		-f $(makefile_dir)/$(STACK)/Dockerfile $(makefile_dir)
@@ -104,6 +109,8 @@ freeze-file: $(STACK)/$(stack_freeze_file)
 .PHONY: core
 core:
 	docker build \
+		--cpu-period="100000" \
+		--cpu-quota="$$(( $(THREADS) * 100000 ))" \
 		--tag pandoc/$(STACK):$(PANDOC_VERSION) \
 		--build-arg pandoc_commit=$(PANDOC_COMMIT) \
 		--build-arg pandoc_version=$(PANDOC_VERSION) \


### PR DESCRIPTION
This will address #156 by limiting the core usage equivalent to the number specified by `CORES`. 

While adding a `DOCKER_ARGS` might be easier to write in terms of the makefile, as you can see, it is not intuitive to provision a number of threads for docker to use. Instead, we have to provision a period and quota.

Folks should be able to use `CORES=5 make core` to run the docker build process with the equivalent of five cores. This overrides cabal's default usage of all processing resources.