### PR TITLE
Architecture independent LaTeX images

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -112,6 +112,9 @@ RUN apk --no-cache add \
 # TeXLive binaries location
 ARG texlive_bin="/opt/texlive/texdir/bin"
 
+# The architecture suffix may vary based on different distributions,
+# particularly for musl libc based distrubions, like Alpine linux,
+# where the suffix is linuxmusl
 RUN TEXLIVE_ARCH="$(uname -m)-linuxmusl" && \
     mkdir -p ${texlive_bin} && \
     ln -sf "${texlive_bin}/${TEXLIVE_ARCH}" "${texlive_bin}/default"

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -109,11 +109,16 @@ RUN apk --no-cache add \
         wget \
         xz
 
-# DANGER: this will vary for different distributions, particularly the
-# `linuxmusl` suffix. Alpine linux is a musl libc based distribution,
-# for other "more common" distributions, you likely want just `-linux`
-# suffix rather than `-linuxmusl` -----> vvvvvvvvv
-ENV PATH="/opt/texlive/texdir/bin/x86_64-linuxmusl:${PATH}"
+# TeXLive binaries location
+ARG texlive_bin="/opt/texlive/texdir/bin"
+
+RUN TEXLIVE_ARCH="$(uname -m)-linuxmusl" && \
+    mkdir -p ${texlive_bin} && \
+    ln -sf "${texlive_bin}/${TEXLIVE_ARCH}" "${texlive_bin}/default"
+
+# Modify PATH environment variable, prepending TexLive bin directory
+ENV PATH="${texlive_bin}/default:${PATH}"
+
 WORKDIR /root
 
 # Installer scripts and config

--- a/common/latex/packages.txt
+++ b/common/latex/packages.txt
@@ -112,4 +112,5 @@ natbib
 # These packages were identified by the tests, they are likely
 # dependencies of dependencies that are not encoded well.
 footnotehyper
+soul
 xurl

--- a/common/latex/packages.txt
+++ b/common/latex/packages.txt
@@ -35,7 +35,7 @@ parskip
 pdflscape   # landscape mode for single pages
 pgf         # for TikZ
 setspace
-ulem
+soul        # Used instead of ulem for strikeout, underline (https://github.com/jgm/pandoc/commit/144bf90ab92b517dd721baf80f121f86187ccd61)
 unicode-math
 xcolor
 
@@ -112,5 +112,4 @@ natbib
 # These packages were identified by the tests, they are likely
 # dependencies of dependencies that are not encoded well.
 footnotehyper
-soul
 xurl

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -136,11 +136,16 @@ RUN apt-get -q --no-allow-insecure-repositories update \
         xzdec \
   && rm -rf /var/lib/apt/lists/*
 
-# DANGER: this will vary for different distributions,
-# particularly the `linux` suffix. Ubuntu linux is a glibc based
-# distribution, adjust depending on the distro.
-# `-linux` ----------------------------> vvvvv
-ENV PATH="/opt/texlive/texdir/bin/x86_64-linux:${PATH}"
+# TeXLive binaries location
+ARG texlive_bin="/opt/texlive/texdir/bin"
+
+RUN TEXLIVE_ARCH="$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]')" && \
+    mkdir -p ${texlive_bin} && \
+    ln -sf "${texlive_bin}/${TEXLIVE_ARCH}" "${texlive_bin}/default"
+
+# Modify PATH environment variable, prepending TexLive bin directory
+ENV PATH="${texlive_bin}/default:${PATH}"
+
 WORKDIR /root
 
 COPY common/latex/texlive.profile /root/texlive.profile


### PR DESCRIPTION
Updated the PATH environment variable assignment in Dockerfile for Alpine and Ubuntu stacks, adding TeXLive binaries using a generic approach