### PR TITLE
Push the extra image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,4 +148,5 @@ jobs:
           if [ "$STACK" != 'static' ]; then
               make push-core
               make push-latex
+              make push-extra
           fi


### PR DESCRIPTION

Hi @tarleb !

Thanks for accepting my proposal ! 

The extra is not visible on docker hub, here's a small patch to activate `push-extra` with github actions... Maybe there are other things to do on the docker hub side. 

Let me know I can help

