### PR TITLE
update base Ubuntu image to Jammy, to resolve dep on liblua-dev==5.4

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,11 +1,11 @@
 # Base ##################################################################
-ARG base_image_version=focal
+ARG base_image_version=jammy
 FROM ubuntu:$base_image_version AS ubuntu-builder-base
 WORKDIR /app
 
 ## Not sure why we have to repeat this, but apparently the arg is no
 ## longer set after FROM.
-ARG base_image_version=focal
+ARG base_image_version=jammy
 ARG lua_version=5.4
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -q --no-allow-insecure-repositories update \


### PR DESCRIPTION
This should resolve issue #193 

Following this change, docker builds for the Ubuntu image complete successfully, using this command from the project root: 
```
docker build -f ubuntu/Dockerfile -t pandoc/latex:local .
``` 

Docker build completes without error: 
```
[+] Building 3381.2s (38/38) FINISHED
``` 

My environment: 
```
% sw_vers
ProductName:		macOS
ProductVersion:		13.2.1
BuildVersion:		22D68

% docker --version
Docker version 20.10.23, build 7155243
``` 