### PR TITLE
Completes Source family by adding sourceserifpro

### DIFF
--- a/common/extra/packages.txt
+++ b/common/extra/packages.txt
@@ -55,6 +55,10 @@ xurl
 zref
 
 #########################################################################
+# Completes Source family
+sourceserifpro
+
+#########################################################################
 # Required by Beamer/Metropolis
 beamertheme-metropolis
 pgfopts


### PR DESCRIPTION
While building a document using dalibo/pandocker, I found that I couldn't get Source Serif Pro to show up but could get its sans and mono versions to work. Turns out, it's just missing!

Work toward https://github.com/dalibo/pandocker/issues/268, which will need a rebuild.