### PR TITLE
FIX #87: Add tectonic to extra

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -187,3 +187,6 @@ ARG LUA_FILTERS_VERSION=v2021-11-05
 RUN wget ${LUA_FILTERS_REPO}/${LUA_FILTERS_VERSION}/lua-filters.tar.gz \
     && tar xzf lua-filters.tar.gz --strip-components=1 --one-top-level=/.pandoc \
     && rm -f lua-filters.tar.gz
+
+# tectonic
+RUN apk --no-cache add tectonic

--- a/docs/extra.md
+++ b/docs/extra.md
@@ -8,11 +8,13 @@ and a curated selection of components:
 * Beamer Themes: [beamer-metropolis][]
 * Pandoc filters: [pandoc-latex-environment][] + [Lua filters][]
 * Open Source Fonts: Font Awesome, Source Code Pro, Source Sans Pro
+* PDF engines: [Tectonic][]
 
 [Eisvogel]: https://github.com/Wandmalfarbe/pandoc-latex-template
 [beamer-metropolis]: https://github.com/matze/mtheme
 [pandoc-latex-environment]: https://github.com/chdemko/pandoc-latex-environment
 [Lua filters]: https://github.com/pandoc/lua-filters
+[Tectonic]: tectonic-typesetting.github.io
 
 [pandoc]: https://pandoc.org/
 [LaTeX]: https://latex-project.org/

--- a/test/Makefile
+++ b/test/Makefile
@@ -190,7 +190,8 @@ EXTRA_CMD = docker run --rm \
 
 .PHONY: test-extra
 test-extra: output/eisvogel.pdf output/eisvogel_with_environment.pdf \
-			output/beamertheme-metropolis.pdf output/lua.html
+			output/beamertheme-metropolis.pdf output/lua.html \
+			output/eisvogel-tectonic.pdf
 
 output/eisvogel.pdf: eisvogel.md
 	$(EXTRA_CMD) $< \
@@ -216,6 +217,12 @@ output/lua.html: eisvogel.md
 	$(EXTRA_CMD) $< \
 	    --output=$@ \
 	    --lua-filter=pagebreak.lua
+
+output/eisvogel-tectonic.pdf: eisvogel.md
+	$(EXTRA_CMD) $< \
+	    --output=$@ \
+	    --template=eisvogel \
+	    --pdf-engine=tectonic
 
 #   ____ _
 #  / ___| | ___  __ _ _ __

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -206,3 +206,16 @@ ARG LUA_FILTERS_VERSION=v2021-11-05
 RUN wget ${LUA_FILTERS_REPO}/${LUA_FILTERS_VERSION}/lua-filters.tar.gz \
     && tar xzf lua-filters.tar.gz --strip-components=1 --one-top-level=/.pandoc \
     && rm -f lua-filters.tar.gz
+
+# tectonic
+ARG TARGETARCH
+ARG TECTONIC_REPO=https://github.com/tectonic-typesetting/tectonic/releases/download
+ARG TECTONIC_VERSION=0.15.0
+RUN if [ "$TARGETARCH" = "amd64" ] ; then TECTONIC_ARCH='x86_64'  ; \
+    elif [ "$TARGETARCH" = "arm64" ] ; then TECTONIC_ARCH='aarch64' ; \
+    else echo 'unsupported target arch for tectonic'; exit 1 ; \
+    fi \
+    && TECTONIC_TARBALL=tectonic-${TECTONIC_VERSION}-${TECTONIC_ARCH}-unknown-linux-gnu.tar.gz \
+    && wget ${TECTONIC_REPO}/tectonic%40${TECTONIC_VERSION}/${TECTONIC_TARBALL} \
+    && tar xzf ${TECTONIC_TARBALL} -C /usr/local/bin/ \
+    && rm -f ${TECTONIC_TARBALL}


### PR DESCRIPTION
Tectonic is a promising pdf engine. 

It's ability to automatically download latex support files on-the-fly could solve a lot of `missing package x` or `missing font y` problems. 

Since this is still experimental, I think we should add it to the `extras` image and maybe move it uptream into the `latex` image in the forthcoming month if it is stable and useful...

Closes #87 