### PR TITLE
FIX #216 : Add cm-super package

### DIFF
--- a/common/extra/packages.txt
+++ b/common/extra/packages.txt
@@ -21,6 +21,7 @@ background
 bidi
 catchfile
 collectbox
+cm-super
 csquotes
 everypage
 filehook

--- a/test/eisvogel.md
+++ b/test/eisvogel.md
@@ -135,3 +135,10 @@ quis lectus elementum fermentum.*
 
 [`pandoc-latex-environments`]: https://github.com/chdemko/pandoc-latex-environment/
 [`awesomebox`]: https://ctan.org/pkg/awesomebox
+
+
+## bug 216 : missing font error
+
+```
+Some block of `code` with `backticks`
+```


### PR DESCRIPTION
The package will add 64MB to the extra image, but it is mandatory because the eisvogel template requires font `tctt1000`.

closes #216 