### PR TITLE
fix: Add pandocfilters to extra requirements

### DIFF
--- a/common/extra/requirements.txt
+++ b/common/extra/requirements.txt
@@ -6,3 +6,4 @@
 #
 
 pandoc-latex-environment==1.1.*
+pandocfilters==1.5.*


### PR DESCRIPTION
Due to an update of pandoc-latex-environment the pip package pandocfilters is not automatically installed. The pandocfilters package is necessary when using [custom build pandoc filters](https://pandoc.org/filters.html#but-i-dont-want-to-learn-haskell).

Adding  [pandocfilters](https://github.com/jgm/pandocfilters) would enable using custom pandoc filters again.

The version 1.5.x is compatible with pandoc versions >= 1.16