### PR TITLE
fix: casing do not match

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -26,7 +26,7 @@ RUN cabal --version \
   && cabal update
 
 # Builder ###############################################################
-FROM alpine-builder-base as alpine-builder
+FROM alpine-builder-base AS alpine-builder
 ARG pandoc_commit=main
 RUN git clone --branch=$pandoc_commit --depth=1 --quiet \
   https://github.com/jgm/pandoc /usr/src/pandoc
@@ -102,7 +102,7 @@ RUN apk --no-cache add librsvg; \
     apk --no-cache add rsvg-convert || true
 
 # LaTeX #################################################################
-FROM alpine-core as alpine-latex
+FROM alpine-core AS alpine-latex
 
 # NOTE: to maintainers, please keep this listing alphabetical.
 RUN apk --no-cache add \
@@ -159,7 +159,7 @@ RUN echo "binary_x86_64-linuxmusl 1" >> /root/texlive.profile \
 WORKDIR /data
 
 # extra ##############################################################
-FROM alpine-latex as alpine-extra
+FROM alpine-latex AS alpine-extra
 
 COPY common/extra/packages.txt /root/extra_packages.txt
 COPY common/extra/requirements.txt /root/extra_requirements.txt

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -19,7 +19,7 @@ RUN apk --no-cache add \
 COPY cabal.root.config /root/.cabal/config
 
 # Builder ###############################################################
-FROM static-builder-base as static-builder
+FROM static-builder-base AS static-builder
 ARG pandoc_commit=main
 RUN git clone --branch=$pandoc_commit --depth=1 --quiet \
   https://github.com/jgm/pandoc /usr/src/pandoc
@@ -51,7 +51,7 @@ RUN find dist-newstyle \
          -exec cp '{}' /usr/local/bin/ ';'
 
 # Minimal ###############################################################
-FROM scratch as static-minimal
+FROM scratch AS static-minimal
 ARG pandoc_version=edge
 LABEL maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'
 LABEL org.pandoc.maintainer='Albert Krewinkel <albert+pandoc@zeitkraut.de>'

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -30,7 +30,7 @@ RUN cabal --version \
   && cabal update
 
 # Builder ###############################################################
-FROM ubuntu-builder-base as ubuntu-builder
+FROM ubuntu-builder-base AS ubuntu-builder
 ARG pandoc_commit=main
 RUN git clone --branch=$pandoc_commit --depth=1 --quiet \
   https://github.com/jgm/pandoc /usr/src/pandoc
@@ -113,7 +113,7 @@ RUN apt-get -q --no-allow-insecure-repositories update \
   && rm -rf /var/lib/apt/lists/*
 
 # LaTeX ##############################################################
-FROM ubuntu-core as ubuntu-latex
+FROM ubuntu-core AS ubuntu-latex
 
 # NOTE: to maintainers, please keep this listing alphabetical.
 RUN apt-get -q --no-allow-insecure-repositories update \
@@ -166,7 +166,7 @@ RUN ( [ -z "$texlive_version"    ] || printf '-t\n%s\n"' "$texlive_version" \
 WORKDIR /data
 
 # extra ##############################################################
-FROM ubuntu-latex as ubuntu-extra
+FROM ubuntu-latex AS ubuntu-extra
 
 COPY common/extra/packages.txt /root/extra_packages.txt
 COPY common/extra/requirements.txt /root/extra_requirements.txt


### PR DESCRIPTION
According to the official Docker documentation, mixed case should be avoided.

ref: [FromAsCasing](https://docs.docker.com/reference/build-checks/from-as-casing/)

```
$ bash build.sh build
[+] Building 0.0s (1/1) FINISHED                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 1.92kB                                     0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (li  0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (li  0.0s

 2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 22)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 54)
```