### PR TITLE
Fix os-string version when building the main branch

### DIFF
--- a/alpine/freeze/pandoc-main.project.freeze
+++ b/alpine/freeze/pandoc-main.project.freeze
@@ -1,5 +1,9 @@
+active-repositories: hackage.haskell.org:merge
 constraints: lua  +system-lua +pkg-config +hardcode-reg-keys -export-dynamic,
              lpeg  -rely-on-shared-lpeg-library,
              aeson-pretty  +lib-only,
              pandoc  +embed_data_files,
-             pandoc-cli  +lua +nightly +server
+             pandoc-cli  +lua +nightly +server,
+             directory +os-string,
+             unix +os-string,
+             any.os-string ==2.0.6,


### PR DESCRIPTION
Otherwise the build fails on Alpine for unknown reasons.