### PR TITLE
Repair broken Markdown links to Tectonic and pandoc/latex

### DIFF
--- a/docs/extra.md
+++ b/docs/extra.md
@@ -15,7 +15,7 @@ and a curated selection of components:
 [pandoc-latex-environment]: https://github.com/chdemko/pandoc-latex-environment
 [Lua filters]: https://github.com/pandoc/lua-filters
 [pandoc-include]: https://github.com/DCsunset/pandoc-include
-[Tectonic]: tectonic-typesetting.github.io
+[Tectonic]: https://tectonic-typesetting.github.io
 
 [pandoc]: https://pandoc.org/
 [LaTeX]: https://latex-project.org/

--- a/docs/sections/other-images.md
+++ b/docs/sections/other-images.md
@@ -15,6 +15,7 @@ The following pandoc images are available:
 
 [**pandoc/minimal**]: https://hub.docker.com/r/pandoc/minimal
 [**pandoc/core**]: https://hub.docker.com/r/pandoc/core
+[**pandoc/latex**]: https://hub.docker.com/r/pandoc/latex
 [**pandoc/extra**]: https://hub.docker.com/r/pandoc/extra
 [**pandoc/typst**]: https://hub.docker.com/r/pandoc/typst
 [Eisvogel template]: https://github.com/Wandmalfarbe/pandoc-latex-template

--- a/test/eisvogel.md
+++ b/test/eisvogel.md
@@ -28,7 +28,7 @@ pandoc-latex-environment:
 
 # Boxes with `pandoc-latex-environment` and `awesomebox`
 
-This example demonstrates the use of the filter [`pandoc-latex-environments`] to create custom boxes with the [`awesomebox`] package. *pandoc-latex-environment* is a pandoc filter for adding LaTeX environement on specific HTML div tags.
+This example demonstrates the use of the filter [`pandoc-latex-environments`] to create custom boxes with the [`awesomebox`] package. *pandoc-latex-environment* is a pandoc filter for adding LaTeX environment on specific HTML div tags.
 
 
 ## Box Types


### PR DESCRIPTION
This fixes a typo, plus these broken links on https://hub.docker.com/r/pandoc/extra (and other DH pages, presumably).

| Missing protocol | Missing URL |
|-|-|
| ![image](https://github.com/user-attachments/assets/a6422631-6554-4dbe-94a5-14adafc225a7) | ![image](https://github.com/user-attachments/assets/1429ea14-7dd7-4005-8613-396be05e8f0c) | 
