### PR TITLE
add xltxtra package to extra

### DIFF
--- a/common/extra/packages.txt
+++ b/common/extra/packages.txt
@@ -52,6 +52,7 @@ ulem
 unicode-math
 upquote
 xecjk
+xltxtra
 xurl
 zref
 


### PR DESCRIPTION
The xltxtra package is a small <200 line .sty file that helps compile some older TeX documents, including my second most commonly used template I've been dragging around for over a decade.  It would be very convenient to have this included.