### PR TITLE
Update eisvogel version from 3.2.0 to 3.3.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ release:
       typst:
         typst: '0.14.0'
       extra:
-        eisvogel: '3.2.0'
+        eisvogel: '3.3.0'
         python:
           - 'pandoc-codeblock-include==1.1.*'
           - 'pandoc-latex-environment==1.2.*'


### PR DESCRIPTION
The Eisvogel template has fixed an incompatibility with pandoc in https://github.com/Wandmalfarbe/pandoc-latex-template/pull/435 and released version 3.3.0. Please update.